### PR TITLE
Fix import

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/src/components/QuickPlayer.tsx
+++ b/src/components/QuickPlayer.tsx
@@ -1,5 +1,5 @@
 import { IconButton } from "@mui/material";
-import { Sample } from "../api";
+import { Sample } from "../api/api";
 import PlayCircleIcon from "@mui/icons-material/PlayCircle";
 import PauseCircleIcon from "@mui/icons-material/PauseCircle";
 import { useState } from "react";


### PR DESCRIPTION
`npm start` and `npm run build` fail because of this. Apparently the CI in the previous PR wasn't actually executed before the merge.